### PR TITLE
Added Workspace::iter_buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 0.7.3
+
+* Add `iter_buffer` method to the `Workspace` type to make it possible to get
+  a list of currently open buffers from the currently selected one.
+
 ### 0.7.2
 
 * Renamed Distance type's `from_str` method to `of_str`, to prevent ambiguity

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "scribe"
-version = "0.7.2"
+version = "0.7.3"
 authors = ["Jordan MacDonald <jordan@wastedintelligence.com>"]
 description = "Text editor toolkit."
 homepage = "https://github.com/jmacdonald/scribe"

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -3,8 +3,43 @@
 use buffer::Buffer;
 use errors::*;
 use std::io;
+use std::cell::Cell;
 use std::path::{Path, PathBuf};
 use syntect::parsing::{SyntaxDefinition, SyntaxSet};
+
+/// Returned as the item in the iterator returned by Workspace::iter_buffers
+///
+/// Note: This item implements the Deref trait so members of Buffer can be
+/// accessed as if it was the real thing.
+pub struct BufferItem<'a> {
+    index: usize,
+    workspace: &'a Workspace,
+    buffer: &'a Buffer,
+}
+
+impl<'a> ::std::ops::Deref for BufferItem<'a> {
+    type Target = Buffer;
+
+    fn deref(&self) -> &Buffer {
+        self.buffer
+    }
+}
+
+impl<'a> BufferItem<'a> {
+    /// Return the path of the buffer following the same logic as
+    /// Workspace::current_buffer_path
+    pub fn get_path(&self) -> Option<&'a Path> {
+        self.buffer.path.as_ref()
+            .and_then(|path| path.strip_prefix(&self.workspace.path).ok()
+                .or_else(|| Some(path))
+            )
+    }
+
+    /// Make this buffer the currently selected one in the workspace
+    pub fn make_current(&self) {
+        self.workspace.current_buffer_index.set(Some(self.index));
+    }
+}
 
 /// An owned collection of buffers and associated path,
 /// representing a running editor environment.
@@ -12,7 +47,7 @@ pub struct Workspace {
     pub path: PathBuf,
     buffers: Vec<Buffer>,
     next_buffer_id: usize,
-    current_buffer_index: Option<usize>,
+    current_buffer_index: Cell<Option<usize>>,
     pub syntax_set: SyntaxSet,
 }
 
@@ -27,7 +62,7 @@ impl Workspace {
             path: try!(path.canonicalize()),
             buffers: Vec::new(),
             next_buffer_id: 0,
-            current_buffer_index: None,
+            current_buffer_index: Cell::new(None),
             syntax_set,
         })
     }
@@ -62,7 +97,7 @@ impl Workspace {
         self.next_buffer_id += 1;
 
         // The target index is directly after the current buffer's index.
-        let target_index = self.current_buffer_index.map(|i| i + 1 ).unwrap_or(0);
+        let target_index = self.current_buffer_index.get().map(|i| i + 1 ).unwrap_or(0);
 
         // Add a syntax definition to the buffer, if it doesn't already have one.
         if buf.syntax_definition.is_none() {
@@ -71,7 +106,7 @@ impl Workspace {
 
         // Insert the buffer and select it.
         self.buffers.insert(target_index, buf);
-        self.current_buffer_index = Some(target_index);
+        self.current_buffer_index.set(Some(target_index));
     }
 
     /// Opens a buffer at the specified path, *inserting
@@ -149,7 +184,7 @@ impl Workspace {
     /// let buffer_reference = workspace.current_buffer().unwrap();
     /// ```
     pub fn current_buffer(&mut self) -> Option<&mut Buffer> {
-        match self.current_buffer_index {
+        match self.current_buffer_index.get() {
             Some(index) => Some(&mut self.buffers[index]),
             None => None,
         }
@@ -182,7 +217,7 @@ impl Workspace {
     /// assert_eq!(workspace.current_buffer_path(), Some(Path::new("file")));
     /// ```
     pub fn current_buffer_path(&self) -> Option<&Path> {
-        self.current_buffer_index
+        self.current_buffer_index.get()
           .and_then(|i| self.buffers[i].path.as_ref()
               .and_then(|path| path.strip_prefix(&self.path).ok()
                   .or_else(|| Some(path))
@@ -215,13 +250,13 @@ impl Workspace {
     /// workspace.close_current_buffer();
     /// ```
     pub fn close_current_buffer(&mut self) {
-        if let Some(index) = self.current_buffer_index {
+        if let Some(index) = self.current_buffer_index.get() {
             self.buffers.remove(index);
 
             if self.buffers.is_empty() {
-                self.current_buffer_index = None;
+                self.current_buffer_index.set(None);
             } else {
-                self.current_buffer_index = index.checked_sub(1).or(Some(0));
+                self.current_buffer_index.set(index.checked_sub(1).or(Some(0)));
             }
         };
     }
@@ -252,12 +287,12 @@ impl Workspace {
     /// workspace.previous_buffer();
     /// ```
     pub fn previous_buffer(&mut self) {
-        match self.current_buffer_index {
+        match self.current_buffer_index.get() {
             Some(index) => {
                 if index > 0 {
-                    self.current_buffer_index = Some(index-1);
+                    self.current_buffer_index.set(Some(index-1));
                 } else {
-                    self.current_buffer_index = Some(self.buffers.len()-1);
+                    self.current_buffer_index.set( Some(self.buffers.len()-1));
                 }
             },
             None => return,
@@ -290,16 +325,56 @@ impl Workspace {
     /// workspace.next_buffer();
     /// ```
     pub fn next_buffer(&mut self) {
-        match self.current_buffer_index {
+        match self.current_buffer_index.get() {
             Some(index) => {
                 if index == self.buffers.len()-1 {
-                    self.current_buffer_index = Some(0);
+                    self.current_buffer_index.set(Some(0));
                 } else {
-                    self.current_buffer_index = Some(index+1);
+                    self.current_buffer_index.set(Some(index+1));
                 }
             },
             None => return,
         }
+    }
+
+    /// Iterate all buffers starting with the current one
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use scribe::Buffer;
+    /// use scribe::Workspace;
+    /// use std::path::Path;
+    ///
+    /// // Set up the paths we'll use.
+    /// let directory_path = Path::new("tests/sample");
+    /// let file_path = Path::new("tests/sample/file");
+    ///
+    /// // Create a workspace.
+    /// let mut workspace = Workspace::new(directory_path).unwrap();
+    ///
+    /// // Add a buffer to the workspace.
+    /// let buf = Buffer::from_file(file_path.clone()).unwrap();
+    /// workspace.add_buffer(buf);
+    ///
+    /// // Add an empty buffer to the workspace
+    /// workspace.add_buffer(Buffer::new());
+    ///
+    /// // Iterate trough the buffers
+    /// let mut it = workspace.iter_buffers()
+    ///     .map(|b| b.get_path());
+    /// assert_eq!(it.next(), Some(None));
+    /// assert_eq!(it.next(), Some(Some(Path::new("file"))));
+    /// assert_eq!(it.next(), None);
+    /// ```
+    pub fn iter_buffers(&self) -> impl Iterator<Item=BufferItem> {
+        let workspace = self;
+        let index = self.current_buffer_index.get().unwrap_or(0);
+        let first_part = self.buffers.iter().enumerate().skip(index);
+        let second_part = self.buffers.iter().enumerate().take(index);
+
+        first_part.chain(second_part)
+            .map(move |(index, buffer)| BufferItem { index, workspace, buffer })
     }
 
     /// Whether or not the workspace contains a buffer with the specified path.
@@ -381,7 +456,7 @@ impl Workspace {
     ///
     /// ```
     pub fn update_current_syntax(&mut self) -> Result<()> {
-        let index = self.current_buffer_index.ok_or(ErrorKind::EmptyWorkspace)?;
+        let index = self.current_buffer_index.get().ok_or(ErrorKind::EmptyWorkspace)?;
         let syntax_definition = self.find_syntax_definition(&self.buffers[index]);
         let buffer = &mut self.buffers[index];
         buffer.syntax_definition = syntax_definition;
@@ -566,7 +641,7 @@ mod tests {
         workspace.add_buffer(Buffer::new());
         workspace.close_current_buffer();
         assert!(workspace.current_buffer().is_none());
-        assert!(workspace.current_buffer_index.is_none());
+        assert!(workspace.current_buffer_index.get().is_none());
     }
 
     #[test]
@@ -689,5 +764,91 @@ mod tests {
         // Ensure that the third buffer is returned.
         workspace.next_buffer();
         assert_eq!(workspace.current_buffer().unwrap().data(), "third buffer");
+    }
+
+    #[test]
+    fn iter_buffers_does_nothing_when_no_buffers_are_open() {
+        let workspace = Workspace::new(Path::new("tests/sample")).unwrap();
+        assert!(workspace.iter_buffers().next().is_none());
+    }
+
+    #[test]
+    fn iter_buffers_when_three_are_open_selects_next_wrapping_to_first() {
+        let mut workspace = Workspace::new(Path::new("tests/sample")).unwrap();
+
+        // Create two buffers and add them to the workspace.
+        let mut first_buffer = Buffer::new();
+        let mut second_buffer = Buffer::new();
+        let mut third_buffer = Buffer::new();
+        first_buffer.insert("first buffer");
+        second_buffer.insert("second buffer");
+        third_buffer.insert("third buffer");
+        workspace.add_buffer(first_buffer);
+        workspace.add_buffer(second_buffer);
+        workspace.add_buffer(third_buffer);
+
+        // Ensure that the third buffer is currently selected.
+        assert_eq!(workspace.current_buffer().unwrap().data(), "third buffer");
+
+        {
+            let mut it = workspace.iter_buffers();
+
+            // Ensure that the third buffer is returned first.
+            assert_eq!(it.next().unwrap().data(), "third buffer");
+
+            // Ensure that it wraps back to the first buffer.
+            assert_eq!(it.next().unwrap().data(), "first buffer");
+
+            // Ensure that the second buffer is returned.
+            assert_eq!(it.next().unwrap().data(), "second buffer");
+
+            // Ensure we reached the end
+            assert!(it.next().is_none());
+        }
+
+        // Ensure that the third buffer is still selected.
+        assert_eq!(workspace.current_buffer().unwrap().data(), "third buffer");
+    }
+
+    #[test]
+    fn iter_buffers_when_three_are_open_make_second_current() {
+        let mut workspace = Workspace::new(Path::new("tests/sample")).unwrap();
+
+        // Create two buffers and add them to the workspace.
+        let mut first_buffer = Buffer::new();
+        let mut second_buffer = Buffer::new();
+        let mut third_buffer = Buffer::new();
+        first_buffer.insert("first buffer");
+        second_buffer.insert("second buffer");
+        third_buffer.insert("third buffer");
+        workspace.add_buffer(first_buffer);
+        workspace.add_buffer(second_buffer);
+        workspace.add_buffer(third_buffer);
+
+        // Ensure that the third buffer is currently selected.
+        assert_eq!(workspace.current_buffer().unwrap().data(), "third buffer");
+
+        {
+            let mut it = workspace.iter_buffers();
+
+            // Ensure that the third buffer is returned first.
+            assert_eq!(it.next().unwrap().data(), "third buffer");
+
+            // Ensure that it wraps back to the first buffer.
+            assert_eq!(it.next().unwrap().data(), "first buffer");
+
+            // Ensure that the second buffer is returned.
+            {
+                let buffer = it.next().unwrap();
+                buffer.make_current();
+                assert_eq!(buffer.data(), "second buffer");
+            }
+
+            // Ensure we reached the end
+            assert!(it.next().is_none());
+        }
+
+        // Ensure that the second buffer is currently selected.
+        assert_eq!(workspace.current_buffer().unwrap().data(), "second buffer");
     }
 }


### PR DESCRIPTION
I implemented a "show open buffers" view in amp a while back and have been using it daily since august. The feature is mostly implemented in amp, but to create a working pull-request it depends on having a way to iterate buffers.

Ref: https://github.com/jmacdonald/amp/issues/141