### PR TITLE
Fix a bug in the read function

### DIFF
--- a/src/buffer/gap_buffer.rs
+++ b/src/buffer/gap_buffer.rs
@@ -110,7 +110,7 @@ impl GapBuffer {
             // The gap is in the middle of the range being requested.
             // Stitch the surrounding halves together to exclude it.
             let first_half = &self.data[start_offset..self.gap_start];
-            let second_half = &self.data[self.gap_start+self.gap_length..end_offset];
+            let second_half = &self.data[self.gap_start+self.gap_length..=end_offset];
 
             // Allocate a string for the first half.
             let mut data = String::from_utf8_lossy(first_half).into_owned();
@@ -121,7 +121,7 @@ impl GapBuffer {
             data
         } else {
             // No gap in the way; just return the requested data range.
-            String::from_utf8_lossy(&self.data[start_offset..end_offset]).into_owned()
+            String::from_utf8_lossy(&self.data[start_offset..=end_offset]).into_owned()
         };
 
         Some(data)


### PR DESCRIPTION
In line 124 of gap_buffer.rs, we find:
```rs
String::from_utf8_lossy(&self.data[start_offset..end_offset]).into_owned()
```
The `end_offset` is actually an index of a character at the end of the range. This character index should be included in the slice. The same applies to one earlier line: line 113.

This proposal modifies the two broken lines of code to use `..=end_offset` instead. Another solution would be `..end_offset+1`.

This proposal might change some behavior in code that relied upon the faulty `read` function. My contribution is licensed MIT.

Thanks!