### PR TITLE
Update synect crate to 4.5.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license-file = "LICENSE"
 keywords = ["gap", "buffer", "text", "editor", "document"]
 
 [dependencies]
-syntect = "~2.1.0"
+syntect = "4.5.0"
 luthor = "~0.1.7"
 unicode-segmentation = "~1.0.1"
 error-chain = "0.10.0"

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -57,7 +57,7 @@ pub struct Buffer {
     history: History,
     operation_group: Option<OperationGroup>,
     pub syntax_definition: Option<SyntaxDefinition>,
-    pub change_callback: Option<Box<Fn(Position)>>,
+    pub change_callback: Option<Box<dyn Fn(Position)>>,
 }
 
 impl Default for Buffer {
@@ -128,7 +128,7 @@ impl Buffer {
         let mut buffer =  Buffer{
             id: None,
             data: data.clone(),
-            path: Some(try!(path.canonicalize())),
+            path: Some(path.canonicalize()?),
             cursor,
             history: History::new(),
             operation_group: None,
@@ -324,7 +324,7 @@ impl Buffer {
     pub fn undo(&mut self) {
         // Look for an operation to undo. First, check if there's an open, non-empty
         // operation group. If not, try taking the last operation from the buffer history.
-        let operation: Option<Box<Operation>> = match self.operation_group.take() {
+        let operation: Option<Box<dyn Operation>> = match self.operation_group.take() {
             Some(group) => {
                 if group.is_empty() {
                     self.history.previous()

--- a/src/buffer/operation/group.rs
+++ b/src/buffer/operation/group.rs
@@ -12,7 +12,7 @@ use buffer::Buffer;
 /// to handle all of their undo/redo implementation details. It exposes two methods on the
 /// buffer type to signal the start and end of a group.
 pub struct OperationGroup {
-    operations: Vec<Box<Operation>>,
+    operations: Vec<Box<dyn Operation>>,
 }
 
 impl Operation for OperationGroup {
@@ -32,7 +32,7 @@ impl Operation for OperationGroup {
 
     /// Build a new operation group by manually cloning all of the groups individual operations.
     /// We can't derive this because operations are unsized and need some hand holding.
-    fn clone_operation(&self) -> Box<Operation> {
+    fn clone_operation(&self) -> Box<dyn Operation> {
         Box::new(OperationGroup{
             operations: self.operations.iter().map(|o| (*o).clone_operation()).collect()
         })
@@ -46,7 +46,7 @@ impl OperationGroup {
     }
 
     /// Adds an operation to the group.
-    pub fn add(&mut self, operation: Box<Operation>) {
+    pub fn add(&mut self, operation: Box<dyn Operation>) {
         self.operations.push(operation);
     }
 

--- a/src/buffer/operation/history.rs
+++ b/src/buffer/operation/history.rs
@@ -6,8 +6,8 @@ use buffer::operation::Operation;
 /// Adding a new operation to the history will clear any previously reversed
 /// operations, which would otherwise have been eligible to be redone.
 pub struct History {
-    previous: Vec<Box<Operation>>,
-    next: Vec<Box<Operation>>,
+    previous: Vec<Box<dyn Operation>>,
+    next: Vec<Box<dyn Operation>>,
     marked_position: Option<usize>
 }
 
@@ -22,7 +22,7 @@ impl History {
     }
 
     /// Store an operation that has already been run.
-    pub fn add(&mut self, operation: Box<Operation>) {
+    pub fn add(&mut self, operation: Box<dyn Operation>) {
         self.previous.push(operation);
         self.next.clear();
 
@@ -35,7 +35,7 @@ impl History {
     }
 
     /// Navigate the history backwards.
-    pub fn previous(&mut self) -> Option<Box<Operation>> {
+    pub fn previous(&mut self) -> Option<Box<dyn Operation>> {
         match self.previous.pop() {
             Some(operation) => {
                 // We've found a previous operation. Before we return it, store a
@@ -48,7 +48,7 @@ impl History {
     }
 
     /// Navigate the history forwards.
-    pub fn next(&mut self) -> Option<Box<Operation>> {
+    pub fn next(&mut self) -> Option<Box<dyn Operation>> {
         match self.next.pop() {
             Some(operation) => {
                 // We've found a subsequent operation. Before we return it, store a

--- a/src/buffer/operation/mod.rs
+++ b/src/buffer/operation/mod.rs
@@ -16,5 +16,5 @@ pub mod history;
 pub trait Operation {
     fn run(&mut self, &mut Buffer);
     fn reverse(&mut self, &mut Buffer);
-    fn clone_operation(&self) -> Box<Operation>;
+    fn clone_operation(&self) -> Box<dyn Operation>;
 }

--- a/src/buffer/operations/delete.rs
+++ b/src/buffer/operations/delete.rs
@@ -41,7 +41,7 @@ impl Operation for Delete {
         }
     }
 
-    fn clone_operation(&self) -> Box<Operation> {
+    fn clone_operation(&self) -> Box<dyn Operation> {
         Box::new(self.clone())
     }
 }

--- a/src/buffer/operations/insert.rs
+++ b/src/buffer/operations/insert.rs
@@ -70,7 +70,7 @@ impl Operation for Insert {
         }
     }
 
-    fn clone_operation(&self) -> Box<Operation> {
+    fn clone_operation(&self) -> Box<dyn Operation> {
         Box::new(self.clone())
     }
 }

--- a/src/buffer/token/token_set.rs
+++ b/src/buffer/token/token_set.rs
@@ -1,20 +1,22 @@
-use syntect::parsing::SyntaxDefinition;
+use syntect::parsing::{SyntaxReference, SyntaxSet};
 use buffer::token::TokenIterator;
 
 pub struct TokenSet<'a> {
     data: String,
-    syntax_definition: &'a SyntaxDefinition,
+    syntax_reference: &'a SyntaxReference,
+    syntax_set: &'a SyntaxSet,
 }
 
 impl<'a> TokenSet<'a> {
-    pub fn new(data: String, def: &SyntaxDefinition) -> TokenSet {
-        TokenSet{
+    pub fn new(data: String, syntax_ref: &'a SyntaxReference, syntax_set: &'a SyntaxSet) -> TokenSet<'a> {
+        TokenSet {
             data,
-            syntax_definition: def
+            syntax_reference: syntax_ref,
+            syntax_set,
         }
     }
 
     pub fn iter(&self) -> TokenIterator {
-        TokenIterator::new(&self.data, self.syntax_definition)
+        TokenIterator::new(&self.data, self.syntax_reference, self.syntax_set)
     }
 }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -24,7 +24,7 @@ impl Workspace {
         syntax_set.link_syntaxes();
 
         Ok(Workspace{
-            path: try!(path.canonicalize()),
+            path: path.canonicalize()?,
             buffers: Vec::new(),
             next_buffer_id: 0,
             current_buffer_index: None,
@@ -117,7 +117,7 @@ impl Workspace {
             // Not going to run into IO errors if we're not opening a buffer.
             Ok(())
         } else {
-            let buffer = try!(Buffer::from_file(path));
+            let buffer = Buffer::from_file(path)?;
             self.add_buffer(buffer);
 
             Ok(())


### PR DESCRIPTION
So after the issue (and small discussion) in https://github.com/jmacdonald/amp/issues/205 I decided to work on updating scribe (and amp) to the current version of the syntect crate, since 3.0.0 introduced some breaking changes.
Although probably not immediately beneficial, having it merged would make updating the syntect crate to future versions much easier.
There's one nice thing though - this crate update brings in all new (and updated) syntax definitions bundled as part of the syntect crate.

I post this now to maybe discuss e.g. if we could make this update / the outward facing API of scribe cleaner regarding syntax handling, if we are already introducing breaking changes.

There seems to be no regressions, having used this branch as part of amp daily for more than a week now + all tests are passing. 