### PR TITLE
Syntect upgrade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ license-file = "LICENSE"
 keywords = ["gap", "buffer", "text", "editor", "document"]
 
 [dependencies]
-syntect = "~2.1.0"
+syntect = { version = "~5", default-features = false, features = ["default-fancy"] }
 luthor = "~0.1.7"
 unicode-segmentation = "~1.0.1"
 error-chain = "0.10.0"

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,18 @@
+{ pkgs ? import <nixpkgs> {}}:
+
+pkgs.mkShell {
+  buildInputs = with pkgs; [
+    rustc
+    cargo
+    rustfmt
+    rust-analyzer
+    clippy
+  ];
+
+  RUST_BACKTRACE = 1;
+
+  shellHook = ''
+    # Vi mode
+    set -o vi
+  '';
+}

--- a/src/buffer/token/token_set.rs
+++ b/src/buffer/token/token_set.rs
@@ -1,20 +1,23 @@
-use syntect::parsing::SyntaxDefinition;
 use crate::buffer::token::TokenIterator;
+use crate::errors::*;
+use syntect::parsing::{SyntaxReference, SyntaxSet};
 
 pub struct TokenSet<'a> {
     data: String,
-    syntax_definition: &'a SyntaxDefinition,
+    syntax_definition: &'a SyntaxReference,
+    syntaxes: &'a SyntaxSet
 }
 
 impl<'a> TokenSet<'a> {
-    pub fn new(data: String, def: &SyntaxDefinition) -> TokenSet {
+    pub fn new(data: String, def: &'a SyntaxReference, syntaxes: &'a SyntaxSet) -> TokenSet<'a> {
         TokenSet{
             data,
-            syntax_definition: def
+            syntax_definition: def,
+            syntaxes
         }
     }
 
-    pub fn iter(&self) -> TokenIterator {
-        TokenIterator::new(&self.data, self.syntax_definition)
+    pub fn iter(&self) -> Result<TokenIterator> {
+        TokenIterator::new(&self.data, self.syntax_definition, self.syntaxes)
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,16 +1,25 @@
+use syntect;
+
 error_chain! {
     errors {
         EmptyWorkspace {
             description("the workspace is empty")
             display("the workspace is empty")
         }
-        MissingSyntaxDefinition {
-            description("buffer is missing a syntax definition")
-            display("buffer is missing a syntax definition")
-        }
         MissingScope {
             description("couldn't find any scopes at the cursor position")
             display("couldn't find any scopes at the cursor position")
         }
+        MissingSyntax {
+            description("no syntax definition for the current buffer")
+            display("no syntax definition for the current buffer")
+        }
+    }
+
+    foreign_links {
+        Io(::std::io::Error) #[cfg(unix)];
+        ParsingError(syntect::parsing::ParsingError);
+        ScopeError(syntect::parsing::ScopeError);
+        SyntaxLoadingError(syntect::LoadingError);
     }
 }

--- a/tests/sample/file2
+++ b/tests/sample/file2
@@ -1,0 +1,1 @@
+it also works!


### PR DESCRIPTION
This PR upgrades the `syntect` dependency to the latest version. Since there are several major version bumps from the current version, there are breaking changes that ultimately affect the public API of `scribe`. The most notable changes are described below.

## TL;DR

### Removed

* `Buffer::tokens(&self)`
* `Buffer::current_scope(&self)`
* `Workspace::current_buffer(&mut self)`
* `Workspace::contains_buffer_with_path(&self, &Path) -> bool`

### Added

* `Buffer::file_extension(&self) -> Option<String>`
* `Workspace::current_buffer_tokens(&'a self) -> Option<TokenSet<'a>>`

### Changed

* `TokenIterator::new(&'a str, &'a SyntaxDefinition) -> TokenIterator<'a>`
  * is now `TokenIterator::new(&'a str, &'a SyntaxDefinition, &'a SyntaxSet) -> TokenIterator<'a>`
* `TokenSet::new(String, &'a SyntaxDefinition) -> TokenSet<'a>`
  * is now `TokenSet::new(String, &'a SyntaxDefinition, &'a SyntaxSet) -> TokenSet<'a>`
* `Workspace::new(&Path) -> Result<Workspace>`
  * is now `Workspace::new(&Path, Option<&Path>) -> Result<Workspace>` to allow loading syntaxes during construction

## Buffer tokenization

Tokenization previously only required a syntax definition, but now requires a `SyntaxSet` too. As a result, buffers are no longer able to produce a `TokenSet` using only their own fields. Given this added dependency, setting up tokenization is now the responsibility of `Workspace::current_buffer_tokens`.

## Current workspace buffer

Accessing the workspace's current buffer was previously done using `Workspace::current_buffer(&mut self)`. Despite the encapsulation benefits this accessor approach provides, Rust isn't smart enough to infer that we're only borrowing one field, and the entire workspace is borrowed for the given lifetime. This was incompatible with the new tokenization requirements, which use both the syntax set from the workspace _and_ the definition from the buffer; calling `current_buffer()` on the workspace would make accessing its `syntax_set` impossible.

To solve this, the current buffer is now accessed directly as a field.

## Error propagation

Syntect now returns proper errors instead of panicking. To make proper use of these, the TokenIterator type has been updated to handle Result-based returns. When an error is discovered, iteration is halted, and the error is stored in a public field on the iterator. This allows consumers to check for errors after iterating, rather than on every returned value during iteration.
